### PR TITLE
Fixed issue where a null reference exception will occur if fetching the user profile fails.

### DIFF
--- a/KitchenSink-WPF/ViewModels/InitiateCallViewModel.cs
+++ b/KitchenSink-WPF/ViewModels/InitiateCallViewModel.cs
@@ -175,7 +175,7 @@ namespace KitchenSink
         private void FetchRecentContacts()
         {
             var spark = ApplicationController.Instance.CurSparkManager.CurSpark;
-            List<string> recentContacts = ApplicationController.Instance.CurSparkManager?.RecentContacts?.RecentContactsStore;
+            List<string> recentContacts = ApplicationController.Instance.CurSparkManager?.RecentContacts?.RecentContactsStore ?? new List<string>(0);
             List<Person> personList = new List<Person>();
 
             foreach (var item in recentContacts)


### PR DESCRIPTION
If fetching the user profile fails, RecentContactsStore is null  and this results in a null reference exception in the foreach that follows:
foreach (var item in recentContacts)